### PR TITLE
update-button-tag

### DIFF
--- a/src/js/components/markmirror.jsx
+++ b/src/js/components/markmirror.jsx
@@ -451,7 +451,7 @@ export default class Markmirror extends React.Component {
     if (this.props.renderButton) {
       return this.props.renderButton(this, command, handler, pressed, title, label);
     }
-    return <Button command={command} handler={handler} pressed={pressed} title={title} label={label} />;
+    return <Button type="button" command={command} handler={handler} pressed={pressed} title={title} label={label} />;
   };
 
   /**


### PR DESCRIPTION
Button tags are, by default, `type="submit"`, which is a W3C Spec.

This causes issue when integrating `react-markmirror` with `redux-form` as custom field, because clicking the button is firing `submit` event.

See the git issue here: https://github.com/erikras/redux-form/issues/3374